### PR TITLE
Force web caches to validate frontpage freshness from server

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -28,17 +28,17 @@ http {
         server_name "";
 
         root /app/dist;
-        index index.html;
 
         location / {
             try_files $uri /index.html;
             expires off;
+            add_header Cache-Control 'no-cache';
         }
 
         ## Cache assets
-        #location ~* ^.+\.(?:css|cur|js|jpe?g|gif|htc|ico|png|html|xml|otf|ttf|eot|woff|svg)$ {
-        #    expires 30d;
-        #}
+        location ~* ^.+\.(?:css|cur|js|jpe?g|gif|htc|ico|png|xml|otf|ttf|eot|woff|svg)$ {
+            expires 30d;
+        }
 
         location /favicon.ico {
             log_not_found off;


### PR DESCRIPTION
Force web caches to validate Koodisto frontpage freshness always from origin server, 
by returning `Cache-Control` HTTP header with `no-cache` directive for frontpage. 

Also re-enable `expire` based caching for assets.  

Actual frontpage freshness check can/will be conditional GET, since Nginx injects proper ETag value to frontpage response, based on responses last modified & content length values, see https://github.com/nginx/nginx/blob/7c5c15a25d22b05f1baabfb14395a7924fe4fd8c/src/http/ngx_http_core_module.c#L1607

Relates to https://jira.csc.fi/browse/YTI-611