### PR TITLE
Fix "no active tab" problem in code scheme

### DIFF
--- a/src/app/components/codescheme/code-scheme.component.ts
+++ b/src/app/components/codescheme/code-scheme.component.ts
@@ -84,7 +84,7 @@ export class CodeSchemeComponent implements OnInit, EditingComponent {
     const schemeCodeValue = this.route.snapshot.params.schemeCode;
 
     this.activatedRoute.queryParams.subscribe(params => {
-      this.initialTabId = params['activeTab'];
+      this.initialTabId = params['activeTab'] ?? this.initialTabId;
     });
 
     if (!registryCodeValue || !schemeCodeValue) {
@@ -230,7 +230,6 @@ export class CodeSchemeComponent implements OnInit, EditingComponent {
   }
 
   onNavChange(event: NgbNavChangeEvent) {
-
     this.languageCodes = null;
 
     if (this.isEditing()) {


### PR DESCRIPTION
In general, one tab should be active all the time in all kind of tab views. There are exceptions but this is the rule of thumb.

This time it was possible to end up in a situation where active tab === undefined. It was caused sometimes in a situation where active tab was not requested in query parameters.

Fixed it by selecting previously selected tab instead of undefined. If previously selected tab is undefined too, it is still possible to end up in the same situation where active tab === undefined.

YTI-1576