### PR TITLE
update yti-common-ui dependency to latest release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,9 @@ ARG NPMRC
 # correct registry
 ARG VERBOSE
 
-# checkout a specific commit id of yti-common-ui project
-ARG COMMON_UI_COMMIT_ID=2ff813cdce4c2e913cb6226192f3757d2599a76b
+# checkout a specific branch & commit of yti-common-ui project
+ARG COMMON_UI_BRANCH=master
+ARG COMMON_UI_COMMIT_ID=cf301e4fddf3b1b8256bee3b94e66caa59bd2415
 
 RUN \
       # Install tooling
@@ -35,6 +36,7 @@ WORKDIR /usr/src
 RUN \
       git clone https://github.com/VRK-YTI/yti-common-ui && \
       cd yti-common-ui && \
+      git -c advice.detachedHead=false checkout $COMMON_UI_BRANCH && \
       git -c advice.detachedHead=false checkout $COMMON_UI_COMMIT_ID && \
       if [ -s "/tmp/_npmrc" ]; then cp /tmp/_npmrc .npmrc; fi && \
       npm `test "$VERBOSE" = "true" && echo "--loglevel verbose"` install && \

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@fortawesome/fontawesome-free-webfonts": "^1.0.9",
     "@ng-bootstrap/ng-bootstrap": "^10.0.0",
     "@ngx-translate/core": "^13.0.0",
-    "@vrk-yti/yti-common-ui": "0.0.1-alpha-20210928.g2ff813c.feature-angular-library",
+    "@vrk-yti/yti-common-ui": "0.0.1",
     "bootstrap": "^4.5.0",
     "material-design-icons": "^3.0.1",
     "moment": "^2.29.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1494,10 +1494,10 @@
     "@types/source-list-map" "*"
     source-map "^0.6.1"
 
-"@vrk-yti/yti-common-ui@0.0.1-alpha-20210924.gcf4edee.feature-angular-library":
-  version "0.0.1-alpha-20210924.gcf4edee.feature-angular-library"
-  resolved "https://npm.pkg.github.com/download/@vrk-yti/yti-common-ui/0.0.1-alpha-20210924.gcf4edee.feature-angular-library/6affcc654dad72af0a7f0af47d330f882beabbe34d169d99bcbd052999d7c997#ff01f39049255877640788bc86dfe6f7920d53e4"
-  integrity sha512-4GIDKVMBVcXtc4V6/9RiChE90n55XbHlPIxpT98T5SB4Tv7edjcTedjT2m4DgYGiEq6uQ61/9j/bY5QdsFa+rA==
+"@vrk-yti/yti-common-ui@0.0.1":
+  version "0.0.1"
+  resolved "https://npm.pkg.github.com/download/@vrk-yti/yti-common-ui/0.0.1/f19ea451b00decc7a2a95bf34dc19d2a1dd8dbf1a00421757ad5d37771a1548c#d5539f2b967c7af1043531701a7473f938741028"
+  integrity sha512-0FoJTbCs7b5rowaJ7OhCiUiw4SzhAkiTFIa/aJfRpN3KhKnRlXtV56ZEwgfEVHjbJIxfuEziNtSMmkMjGyw0VA==
   dependencies:
     tslib "^2.1.0"
 


### PR DESCRIPTION
`yti-common-ui` now has a release of `0.0.1` in the github npm registry. This PR updates the dependency in `package.json`. For `Dockerfile`, the dependency is updated using branch & commit id.

Possible future imporvement for `Dockerfile` might be to use a remote tag instead.