### PR TITLE
YTI-1592 child organizations

### DIFF
--- a/src/app/components/form/organizations-input.component.ts
+++ b/src/app/components/form/organizations-input.component.ts
@@ -44,7 +44,7 @@ function removeFromControl<T>(control: FormControl, itemToRemove: T) {
                  class="fa fa-times"
                  (click)="removeOrganization(organization)"></i>
             </a>
-            <span>{{organization.getDisplayName(languageService, true)}}</span>
+            <span>{{organization.getEditModeDisplayName(languageService, true)}}</span>
           </div>
           <app-error-messages id="organization_error_messages" [control]="parentControl"></app-error-messages>
         </div>

--- a/src/app/entities/organization.ts
+++ b/src/app/entities/organization.ts
@@ -21,6 +21,11 @@ export class Organization {
     return localizer.translate(this.prefLabel, useUILanguage);
   }
 
+  getEditModeDisplayName(localizer: Localizer, useUILanguage: boolean = false): string {
+    const parentName = this.parent ? ` (${localizer.translate(this.parent.prefLabel, useUILanguage)})` : '';
+    return this.getDisplayName(localizer, useUILanguage) + parentName;
+  }
+
   getIdIdentifier(localizer: Localizer): string {
     const prefLabel = localizer.translate(this.prefLabel);
     return `${labelNameToResourceIdIdentifier(prefLabel)}`;

--- a/src/app/services/authorization-manager.service.ts
+++ b/src/app/services/authorization-manager.service.ts
@@ -38,23 +38,12 @@ export class AuthorizationManager {
     return false;
   }
 
-  filterAllowedRegistriesForUser(codeRegistries: CodeRegistry[], allOrganizations: Organization[]): CodeRegistry[] {
-
-    // Grant privileges for child organization users to parent organization's registry
-    const mapIds = (result: string[], organization: Organization) => {
-      const child = allOrganizations.find(org => org.parent && org.parent.id === organization.id);
-      if (child) {
-        result.push(child.id);
-      }
-      result.push(organization.id);
-      return result;
-    }
-
+  filterAllowedRegistriesForUser(codeRegistries: CodeRegistry[]): CodeRegistry[] {
     return codeRegistries.filter(registry =>
-      this.user.superuser || this.user.isInRole(['ADMIN', 'CODE_LIST_EDITOR'], registry.organizations.reduce(mapIds, [])));
+      this.user.superuser || this.user.isInRole(['ADMIN', 'CODE_LIST_EDITOR'], registry.organizations.map(org => org.id)));
   }
 
   canCreateCodeScheme(codeRegistries: CodeRegistry[]) {
-    return this.user.superuser || codeRegistries.length > 0;
+    return this.user.superuser || codeRegistries?.length > 0;
   }
 }

--- a/src/app/services/data.service.ts
+++ b/src/app/services/data.service.ts
@@ -118,13 +118,7 @@ export class DataService {
   }
 
   getCodeRegistriesForUser(): Observable<CodeRegistry[]> {
-
-    return this.getCodeRegistries().pipe(
-      mergeMap(reg => combineLatest([ of(reg), this.getOrganizations() ])),
-      map(([codeRegistries, organizations]) => {
-        return this.authorizationManager.filterAllowedRegistriesForUser(codeRegistries, organizations);
-      })
-    );
+    return this.getCodeRegistries().pipe(map(r => this.authorizationManager.filterAllowedRegistriesForUser(r)));
   }
 
   getOrganizations(): Observable<Organization[]> {


### PR DESCRIPTION
Some improvements for PR #47 

* Simplify the implementation for checking access to code registry. Also child organizations will be added to parent's code registries in the UI instead of determining access based on parent organization id
* Show parent organization's name in editing mode